### PR TITLE
WIP: Add comment parsing from CastXML

### DIFF
--- a/pygccxml/declarations/comment.py
+++ b/pygccxml/declarations/comment.py
@@ -1,0 +1,52 @@
+# Copyright 2014-2017 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+"""
+Describe a C++ comment declaration.
+
+"""
+
+
+from . import declaration
+
+
+class comment_t(declaration.declaration_t):
+
+    def __init__(self, name='', declarations=None):
+        """
+        Creates an object that describes a C++ comment declaration.
+
+        Args:
+
+        """
+        declaration.declaration_t.__init__(self, name)
+        self.location = {}
+        self._start_line = 0
+        self._end_line = 0
+        self._text = ""
+
+    @property
+    def start_line(self):
+        return self._start_line
+
+    @start_line.setter
+    def start_line(self, start_line):
+        self._start_line = int(start_line)
+
+    @property
+    def end_line(self):
+        return self._end_line
+
+    @end_line.setter
+    def end_line(self, end_line):
+        self._end_line = int(end_line)
+
+    @property
+    def text(self):
+        return self._text
+
+    @text.setter
+    def text(self, text):
+        self._text = text

--- a/pygccxml/declarations/decl_factory.py
+++ b/pygccxml/declarations/decl_factory.py
@@ -12,6 +12,7 @@ from .calldef_members import constructor_t
 from .calldef_members import destructor_t
 from .calldef_members import member_operator_t
 from .calldef_members import casting_operator_t
+from .comment import comment_t
 from .free_calldef import free_function_t
 from .free_calldef import free_operator_t
 from .enumeration import enumeration_t
@@ -89,3 +90,7 @@ class decl_factory_t(object):
     def create_variable(self, *arguments, **keywords):
         """creates instance of class that describes variable declaration"""
         return variable_t(*arguments, **keywords)
+
+    def create_comment(self, *arguments, **keywords):
+        """creates instance of class that describes variable declaration"""
+        return comment_t(*arguments, **keywords)

--- a/pygccxml/declarations/decl_visitor.py
+++ b/pygccxml/declarations/decl_visitor.py
@@ -57,3 +57,6 @@ class decl_visitor_t(object):
 
     def visit_variable(self):
         raise NotImplementedError()
+
+    def visit_comment(self):
+        raise NotImplementedError()

--- a/pygccxml/declarations/declaration.py
+++ b/pygccxml/declarations/declaration.py
@@ -37,6 +37,7 @@ class declaration_t(object):
         self._cache = algorithms_cache.declaration_algs_cache_t()
         self._partial_name = None
         self._decorated_name = None
+        self._comment = None
 
     def __str__(self):
         """
@@ -338,3 +339,11 @@ class declaration_t(object):
             "Please use the declarations.get_dependencies_from_decl()" +
             "function instead.\n",
             DeprecationWarning)
+
+    @property
+    def comment(self):
+        return self._comment
+
+    @comment.setter
+    def comment(self, comment):
+        self._comment = comment

--- a/pygccxml/parser/linker.py
+++ b/pygccxml/parser/linker.py
@@ -107,6 +107,9 @@ class linker_t(
     def visit_member_operator(self):
         self.__link_calldef()
 
+    def visit_comment(self):
+        pass
+
     def visit_casting_operator(self):
         self.__link_calldef()
         # FIXME: is the patch still needed as the demangled name support has

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(name="pygccxml",
                 "pygccxml.declarations",
                 "pygccxml.parser",
                 "pygccxml.utils"],
+      install_requires=[
+          "castxml>=0.3.6"],
       extras_require={
           "test": list(requirements_test),
           "docs": list(requirements_docs),

--- a/unittests/data/test_comments.hpp
+++ b/unittests/data/test_comments.hpp
@@ -1,0 +1,23 @@
+// Copyright 2014-2017 Insight Software Consortium.
+// Copyright 2004-2009 Roman Yakovenko.
+// Distributed under the Boost Software License, Version 1.0.
+// See http://www.boost.org/LICENSE_1_0.txt
+
+/** class comment */
+class test
+{
+public:
+  // Non-doc comment before.
+  /** doc comment */
+  // Non-doc comment after.
+  test();
+
+  /// cxx comment
+  /// with multiple lines
+  int hello();
+
+  //! mutable field comment
+  int val1 = 0;
+  /// bit field comment
+  double val2=2;
+};

--- a/unittests/test_all.py
+++ b/unittests/test_all.py
@@ -83,6 +83,7 @@ from . import test_order
 from . import test_find_noncopyable_vars
 from . import test_hash
 from . import test_null_comparison
+from . import test_comments
 
 testers = [
     pep8_tester,
@@ -157,6 +158,7 @@ testers = [
     test_find_noncopyable_vars,
     test_hash,
     test_null_comparison,
+    test_comments,
 ]
 
 if platform.system() != 'Windows':

--- a/unittests/test_comments.py
+++ b/unittests/test_comments.py
@@ -1,0 +1,65 @@
+# Copyright 2014-2020 Insight Software Consortium.
+# Copyright 2004-2009 Roman Yakovenko.
+# Distributed under the Boost Software License, Version 1.0.
+# See http://www.boost.org/LICENSE_1_0.txt
+
+import unittest
+
+from . import parser_test_case
+
+from pygccxml import parser
+from pygccxml import declarations
+
+
+class Test(parser_test_case.parser_test_case_t):
+    global_ns = None
+
+    def __init__(self, *args):
+        parser_test_case.parser_test_case_t.__init__(self, *args)
+        self.header = "test_comments.hpp"
+        self.global_ns = None
+        self.config.castxml_epic_version = 1
+
+    def setUp(self):
+
+        if not self.global_ns:
+            decls = parser.parse([self.header], self.config)
+            Test.global_ns = declarations.get_global_namespace(decls)
+            Test.xml_generator_from_xml_file = \
+                self.config.xml_generator_from_xml_file
+        self.xml_generator_from_xml_file = Test.xml_generator_from_xml_file
+        self.global_ns = Test.global_ns
+
+    def test(self):
+        """
+        Check the comment parsing
+        """
+        if self.config.castxml_epic_version != 1:
+            # Run this test only with castxml epic version == 1
+            return
+        tclass = self.global_ns.class_("test")
+        self.assertIn("comment", dir(tclass))
+        self.assertEqual(["/** class comment */"], tclass.comment.text)
+
+        tmethod = tclass.member_functions()[0]
+
+        self.assertIn("comment", dir(tmethod))
+        self.assertEqual(["  /// cxx comment", "  /// with multiple lines"], tmethod.comment.text)
+
+        tconstructor = tclass.constructors()[0]
+
+        self.assertIn("comment", dir(tconstructor))
+        self.assertEqual(["  /** doc comment */"], tconstructor.comment.text)
+
+def create_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(Test))
+    return suite
+
+
+def run_suite():
+    unittest.TextTestRunner(verbosity=2).run(create_suite())
+
+
+if __name__ == "__main__":
+    run_suite()


### PR DESCRIPTION
Todo: 

- [ ]  Determine if "endDocument" is the best place to link the comments.  Should it happen in visit_comment?
- [ ]  Determine best way to test CastXML for version before running test.  Should only execute on version >3.4
- [ ]  Determine if adding CastXML as PIP installation dependency during setup is desirable.